### PR TITLE
add .nomad to hcl-mode

### DIFF
--- a/hcl-mode.el
+++ b/hcl-mode.el
@@ -210,6 +210,7 @@
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.hcl\\'" . hcl-mode))
+(add-to-list 'auto-mode-alist '("\\.nomad\\'" . hcl-mode))
 
 (provide 'hcl-mode)
 


### PR DESCRIPTION
[nomad](https://www.nomadproject.io/) uses `.nomad` extension
