### PR TITLE
Fix syntax highlighting for multiline string interpolation. Close #7

### DIFF
--- a/hcl-mode.el
+++ b/hcl-mode.el
@@ -40,9 +40,8 @@
 (defconst hcl--block-regexp
   "^\\s-*[^{]+{")
 
-;; String Interpolation(This regexp is taken from ruby-mode)
 (defconst hcl--string-interpolation-regexp
-  "\\${[^}\n\\\\]*\\(?:\\\\.[^}\n\\\\]*\\)*}")
+  "\\${\\([^}]\\|\n\\)*}?")
 
 (defconst hcl--assignment-regexp
   "\\s-*\\([[:word:]]+\\)\\s-*=\\(?:[^>=]\\)")
@@ -189,6 +188,7 @@
   "Major mode for editing hcl configuration file"
 
   (setq font-lock-defaults '((hcl-font-lock-keywords)))
+  (setq font-lock-multiline t)
 
   (modify-syntax-entry ?_ "w" hcl-mode-syntax-table)
 

--- a/test/test-highlighting.el
+++ b/test/test-highlighting.el
@@ -86,6 +86,17 @@ bar = \"${foo}\"
     (forward-char 1)
     (should (face-at-cursor-p 'font-lock-variable-name-face))))
 
+(ert-deftest multiline-string-interpolation ()
+  "Syntax highlight of multi-line string interpolation"
+  (with-hcl-temp-buffer
+   "
+foo = \"${1
++ 1}\""
+
+   (forward-cursor-on "{1")
+   (forward-char 1)
+   (should (face-at-cursor-p 'font-lock-variable-name-face))))
+
 (ert-deftest single-line-comment ()
   "Syntax highlight of single line comment"
 


### PR DESCRIPTION
Thank you for your work in developing this package, I've learnt a lot about clean Emacs package development from reading the source :D.

Just a quick note on this line that I added:

```elisp
(setq font-lock-multiline t)
```

We need it to signal to Emacs that it should re-compute the syntax highlighting across the buffer after a short period of idle time. Without this line, the syntax highlighting is only recomputed for the line that was just edited. This is important when a editing a line should change the syntax highlighting of subsequent lines, e.g. editing the middle line

```hcl
foo = "${1 +
2 + 3 +
4}"
```

to

```hcl
foo = "${1 +
2} + 3 +
4}"
```

and the reverse operation.

Unfortunately I couldn't figure out a way of testing this behaviour, because the syntax highlighting update is only done after a delay—if you have any ideas on how this could be tested I'd love to hear them!
