### PR TITLE
Support `-` by key of assignment and map regexp

### DIFF
--- a/hcl-mode.el
+++ b/hcl-mode.el
@@ -45,10 +45,10 @@
   "\\${[^}\n\\\\]*\\(?:\\\\.[^}\n\\\\]*\\)*}")
 
 (defconst hcl--assignment-regexp
-  "\\s-*\\([[:word:]]+\\)\\s-*=\\(?:[^>=]\\)")
+  "\\s-*\\([[:word:]\\-]+\\)\\s-*=\\(?:[^>=]\\)")
 
 (defconst hcl--map-regexp
-  "\\s-*\\([[:word:]]+\\)\\s-*{")
+  "\\s-*\\([[:word:]\\-]+\\)\\s-*{")
 
 (defconst hcl--boolean-regexp
   (concat "\\(?:^\\|[^.]\\)"


### PR DESCRIPTION
It may not be a good practice, however it should be available in the HCL/JSON specification.