### PR TITLE
Syntax highlighting fixes

### DIFF
--- a/test/test-highlighting.el
+++ b/test/test-highlighting.el
@@ -60,6 +60,14 @@ foo=\"var\"
 
   (with-hcl-temp-buffer
     "
+    foo-bar =      \"var\"
+"
+
+   (forward-cursor-on "foo")
+   (should (face-at-cursor-p 'font-lock-variable-name-face)))
+
+  (with-hcl-temp-buffer
+    "
 output \"name\" {
    bar = \"baz\"
    map {


### PR DESCRIPTION
* "-" is a valid symbol character: prefer symbol syntax for that, and "_"
* Remove unused "let" binding
* Fix typo in docstring for defgroup

The first of these is a more idiomatic version of #11.